### PR TITLE
Do not send message if no webhook url is available

### DIFF
--- a/src/Gahlawat/Slack/Slack.php
+++ b/src/Gahlawat/Slack/Slack.php
@@ -27,6 +27,10 @@ class Slack
 
     public function send($message, $username = '', $emoji = '')
     {
+        if (!config('slack.incoming-webhook')) {
+            return;
+        }
+        
         if (!trim($username)) {
             $username = $this->defaultUsername;
         }


### PR DESCRIPTION
This is useful if you want to send notifications from your production environment but not from your development environment. Currently it throws an exception if you don't fill in a webhook